### PR TITLE
Feat/category pages

### DIFF
--- a/_posts/balance/app.md
+++ b/_posts/balance/app.md
@@ -4,7 +4,7 @@ excerpt: "Balance is Chile’s top-rated transit app."
 client:
   - "Balance"
 clientSector:
-  - "Transport"
+  - "Mobility & Transport"
 workType:
   - "Product Design"
   - "Engineering"

--- a/_posts/guemil.md
+++ b/_posts/guemil.md
@@ -3,8 +3,7 @@ title: "Guemil — Icons for Emergency"
 excerpt: "Designed and implemented multiple internal tools and APIs to automate icon testing and visualization for \"Guemil, Icons for Emergency\"."
 client: "Guemil"
 clientSector:
-  - "NGOs"
-  - "Design"
+  - "Not-for-Profit"
 workType:
   - "Product Design"
   - "Engineering"

--- a/_posts/kappo/cool-place-to-bike-website.md
+++ b/_posts/kappo/cool-place-to-bike-website.md
@@ -3,7 +3,7 @@ title: "Cool Place to Bike Website"
 excerpt: "Website redesign and development for Kappo's Cool Place to Bike program."
 client: "Kappo Bike"
 clientSector:
-  - "Mobility"
+  - "Mobility & Transport"
   - "Start-up"
 workType:
   - "Product Design"

--- a/_posts/kappo/kappo-brand-identity.md
+++ b/_posts/kappo/kappo-brand-identity.md
@@ -3,7 +3,7 @@ title: "Kappo Bike — Brand Identity Redesign"
 excerpt: "Brand identity redesign for Kappo Bike, a now-defunct app for logging your bicycle trips around the city."
 client: "Kappo Bike"
 clientSector:
-  - "Mobility"
+  - "Mobility & Transport"
   - "Start-up"
 workType:
   - "Brand Identity"

--- a/_posts/lintuaf.md
+++ b/_posts/lintuaf.md
@@ -2,7 +2,7 @@
 title: "Lintuaf — An unofficial Fintual client for iOS"
 excerpt: "Fintual is a Chilean fintech startup offering a low-cost, user-friendly platform for investing in diversified portfolios. Lintuaf is a private iOS client I made for myself."
 clientSector:
-  - "Independent"
+  - "Banking & Finance"
 workType:
   - "Product Design"
   - "Engineering"

--- a/_posts/santiago-transit-map/2018.md
+++ b/_posts/santiago-transit-map/2018.md
@@ -2,7 +2,8 @@
 title: "Santiago Transit Map 2018"
 excerpt: "Transit map for Santiago de Chile's Metro & rail network."
 clientSector:
-  - "Mobility"
+  - "Mobility & Transport"
+  - "Civic & Public"
 workType:
   - "Graphic Design"
 startYear: 2018

--- a/_posts/santiago-transit-map/2019.md
+++ b/_posts/santiago-transit-map/2019.md
@@ -2,7 +2,8 @@
 title: "Santiago Transit Map 2019"
 excerpt: "Transit map for Santiago de Chile's Metro & rail network."
 clientSector:
-  - "Mobility"
+  - "Mobility & Transport"
+  - "Civic & Public"
 workType:
   - "Graphic Design"
 startYear: 2019

--- a/_posts/y4pt.md
+++ b/_posts/y4pt.md
@@ -2,7 +2,8 @@
 title: "Y4PT 2nd Transport Hackathon Chile 2017"
 excerpt: "Branding and graphic design for Y4PT’s 2nd Chilean National Transport Hackathon."
 clientSector:
-  - "Mobility"
+  - "Mobility & Transport"
+  - "Not-for-Profit"
 workType:
   - "Brand Identity"
   - "Graphic Design"

--- a/components/NextProjectPeek/NextProjectPeek.js
+++ b/components/NextProjectPeek/NextProjectPeek.js
@@ -10,7 +10,7 @@ export default function NextProjectPeek({
         <div className="next_project_peek">
             <hr />
             <div className="project_article_header_container">
-                <ProjectArticleHeader postData={nextPostData} autoPlayThumbnail={false} />
+                <ProjectArticleHeader peek={true} postData={nextPostData} autoPlayThumbnail={false} />
             </div>
 
             <Link href={`/design/${nextPostData.project}`} prefetch={false} className="project_access">

--- a/components/ProjectArticleHeader/ProjectArticleHeader.js
+++ b/components/ProjectArticleHeader/ProjectArticleHeader.js
@@ -2,6 +2,7 @@ import Balancer from 'react-wrap-balancer'
 import { ProjectThumbnail } from '../ProjectThumbnail/ProjectThumbnail'
 import './ProjectArticleHeader.scss'
 import Link from 'next/link'
+import { normalizeForUrl } from '@/lib/formatters'
 
 export function ProjectArticleHeader({
     peek = false,
@@ -19,7 +20,7 @@ export function ProjectArticleHeader({
                 <p className="subtitle">
                     {postData.workType?.map((workType, i) => (
                         <Link
-                            href={`/work/discipline/${workType.toLowerCase().replace(/[&]/g, '').replace(/\s+/g, '-')}`}
+                            href={`/work/discipline/${normalizeForUrl(workType)}`}
                             key={i}
                         >
                             {workType}

--- a/components/ProjectArticleHeader/ProjectArticleHeader.js
+++ b/components/ProjectArticleHeader/ProjectArticleHeader.js
@@ -1,21 +1,31 @@
 import Balancer from 'react-wrap-balancer'
 import { ProjectThumbnail } from '../ProjectThumbnail/ProjectThumbnail'
-import { formatYears, formatCategories } from '@/lib/formatters'
 import './ProjectArticleHeader.scss'
+import Link from 'next/link'
 
 export function ProjectArticleHeader({
+    peek = false,
     postData,
     autoPlayThumbnail = true,
 }) {
     return (
-        <div className="project_article_header">
+        <div className="project_article_header" data-peek={peek}>
             <div className="basic_info">
                 <h2 className="title">
                     <Balancer>
                         {postData.title}
                     </Balancer>
                 </h2>
-                <p className="period">{formatCategories(postData.workType)}</p>
+                <p className="subtitle">
+                    {postData.workType?.map((workType, i) => (
+                        <Link
+                            href={`/work/discipline/${workType.toLowerCase().replace(/[&]/g, '').replace(/\s+/g, '-')}`}
+                            key={i}
+                        >
+                            {workType}
+                        </Link>
+                    )).reduce((prev, curr) => [prev, ', ', curr])}
+                </p>
             </div>
             <p className="excerpt">
                 <Balancer>
@@ -24,7 +34,7 @@ export function ProjectArticleHeader({
             </p>
             <ProjectThumbnail
                 coverImage={postData.coverImage}
-                autoplay={true}
+                autoplay={autoPlayThumbnail}
                 img_only
                 placeholder={false}
             />

--- a/components/ProjectArticleHeader/ProjectArticleHeader.scss
+++ b/components/ProjectArticleHeader/ProjectArticleHeader.scss
@@ -60,9 +60,13 @@
                 position: relative;
                 padding-bottom: 1px;
                 margin-bottom: -1px;
+                color: rgba(136, 138, 144, 1);
+                transition: color .3s cubic-bezier(.25, .46, .45, .94) 0s;
 
                 @media (hover: hover) {
                     &:hover {
+                        color: #000;
+
                         &::after {
                             background-color: rgb(136, 138, 144);
 

--- a/components/ProjectArticleHeader/ProjectArticleHeader.scss
+++ b/components/ProjectArticleHeader/ProjectArticleHeader.scss
@@ -48,13 +48,49 @@
             line-height: 1.2em;
         }
 
-        .period {
+        .subtitle {
             color: rgba(136, 138, 144, 1);
             font-size: 15px;
             font-weight: 460;
             line-height: 1.4;
             margin: 8px 0 0;
             padding: 0;
+
+            a {
+                position: relative;
+                padding-bottom: 1px;
+                margin-bottom: -1px;
+
+                @media (hover: hover) {
+                    &:hover {
+                        &::after {
+                            background-color: rgb(136, 138, 144);
+
+                            @at-root [data-peek="true"]#{&} {
+                                background-color: transparent;
+                            }
+                        }
+                    }
+                }
+
+                &::after {
+                    content: "";
+                    display: block;
+                    width: 100%;
+                    height: 1px;
+                    border-radius: 2px;
+                    background-color: rgb(231, 232, 233);
+                    transition: background-color .3s cubic-bezier(.25, .46, .45, .94) 0s;
+                    position: absolute;
+                    right: 0;
+                    bottom: 0;
+                    left: 0;
+
+                    @at-root [data-peek="true"]#{&} {
+                        background-color: transparent;
+                    }
+                }
+            }
         }
     }
 

--- a/components/ProjectCollection/ProjectCollection.js
+++ b/components/ProjectCollection/ProjectCollection.js
@@ -1,0 +1,84 @@
+import { ProjectThumbnail } from '@/components/ProjectThumbnail/ProjectThumbnail'
+import GlobalHeader from '@/components/GlobalHeader/GlobalHeader'
+import ProjectsGrid from '@/components/ProjectsGrid/ProjectsGrid'
+import GlobalFooter from '@/components/GlobalFooter/GlobalFooter'
+import { NextSeo } from 'next-seo'
+
+export default function ProjectCollection({
+    title,
+    posts,
+    server,
+    subtitle,
+    description = "Digital Product Designer & Engineer. Featured works include projects for Uber, Uber Eats, Cornershop, among others."
+}) {
+    const _renderThumbnail = (project, index, priority) => {
+        return (
+            <ProjectThumbnail
+                {...project}
+                id={project.id}
+                as="article"
+                hover
+                key={index}
+                fadeIn={false}
+                priority={priority}
+            />
+        )
+    }
+
+    return (
+        <>
+            <NextSeo
+                title={`${title} — Laura Sandoval`}
+                description={description}
+                openGraph={{
+                    title: `${title} — Laura Sandoval`,
+                    description: description,
+                    images: posts.length > 0 ? [
+                        {
+                            url: `${server}${posts[0].ogImage}`,
+                        }
+                    ] : [],
+                }}
+                twitter={{
+                    handle: "@laurasideral",
+                    cardType: "summary_large_image",
+                }}
+                additionalLinkTags={[
+                    {
+                        rel: "icon",
+                        href: `${server}/favicon.ico`,
+                    },
+                    {
+                        rel: "apple-touch-icon",
+                        href: `${server}/logo192.png`
+                    }
+                ]}
+                additionalMetaTags={[
+                    {
+                        name: "theme-color",
+                        content: "#FFFFFF",
+                    },
+                ]}
+            />
+
+            <GlobalHeader sticky fadeIn={false} />
+
+            <div className="folder_page">
+                <div className="folder_name_header">
+                    <div className="basic_info">
+                        <h2 className="title">{title}</h2>
+                        <h2 className="subtitle">{subtitle || `${posts.length} ${posts.length === 1 ? "project" : "projects"}`}</h2>
+                    </div>
+                </div>
+
+                <ProjectsGrid showAll>
+                    {posts.map((project, index) => {
+                        return _renderThumbnail(project, index, (index == 0 || index == 1))
+                    })}
+                </ProjectsGrid>
+            </div>
+
+            <GlobalFooter />
+        </>
+    )
+} 

--- a/components/ProjectCollection/ProjectCollection.js
+++ b/components/ProjectCollection/ProjectCollection.js
@@ -3,6 +3,7 @@ import GlobalHeader from '@/components/GlobalHeader/GlobalHeader'
 import ProjectsGrid from '@/components/ProjectsGrid/ProjectsGrid'
 import GlobalFooter from '@/components/GlobalFooter/GlobalFooter'
 import { NextSeo } from 'next-seo'
+import './ProjectCollection.scss'
 
 export default function ProjectCollection({
     title,
@@ -63,8 +64,8 @@ export default function ProjectCollection({
 
             <GlobalHeader sticky fadeIn={false} />
 
-            <div className="folder_page">
-                <div className="folder_name_header">
+            <div className="project_collection_page">
+                <div className="header">
                     <div className="basic_info">
                         <h2 className="title">{title}</h2>
                         <h2 className="subtitle">{subtitle || `${posts.length} ${posts.length === 1 ? "project" : "projects"}`}</h2>

--- a/components/ProjectCollection/ProjectCollection.scss
+++ b/components/ProjectCollection/ProjectCollection.scss
@@ -1,4 +1,4 @@
-.folder_page {
+.project_collection_page {
     margin: 0 auto;
     padding-top: 80px;
     max-width: 1600px;
@@ -8,7 +8,7 @@
         padding-top: 40px;
     }
 
-    .folder_name_header {
+    >.header {
         --max-width: 1280px;
         --grid-gap: 40px;
         display: grid;

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -9,3 +9,11 @@ export function formatYears(startYear, endYear) {
         return null;
     }
 };
+
+export function normalizeForUrl(str) {
+    return str
+        .toLowerCase()
+        .replace(/[&]/g, 'and')  // Replace & with 'and'
+        .replace(/[^a-z0-9]+/g, '-')  // Replace any non-alphanumeric chars with hyphen
+        .replace(/^-+|-+$/g, '');  // Remove leading/trailing hyphens
+}

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,13 +1,3 @@
-export function formatCategories(categories) {
-    if (!categories || categories.length === 0) return null;
-
-    if (categories.length === 1) {
-        return categories[0];
-    } else {
-        return categories.slice(0, 3).join(', ');
-    }
-};
-
 export function formatYears(startYear, endYear) {
     if (startYear && endYear) {
         return startYear === endYear ? `${startYear}` : `${startYear} — ${endYear}`;

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -129,3 +129,31 @@ export function getEarliestYear() {
 
     return earliestYear;
 }
+
+export function getAllWorkTypes() {
+    const allPosts = getSortedPostsData();
+    const workTypes = new Set();
+
+    allPosts.forEach(post => {
+        if (post.workType) {
+            post.workType.forEach(type => {
+                // Convert to URL-friendly format
+                const urlType = type.toLowerCase().replace(/\s+/g, '-').replace(/[&]/g, '');
+                workTypes.add(urlType);
+            });
+        }
+    });
+
+    return Array.from(workTypes);
+}
+
+export function getPostsByWorkType(workType) {
+    const allPosts = getSortedPostsData();
+    return allPosts.filter(post => {
+        if (!post.workType) return false;
+        const normalizedWorkType = workType.replace(/-/g, ' ').toLowerCase();
+        return post.workType.some(type =>
+            type.toLowerCase() === normalizedWorkType
+        );
+    });
+}

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -3,6 +3,7 @@ import path from 'path';
 import matter from 'gray-matter';
 import { remark } from 'remark';
 import html from 'remark-html';
+import { normalizeForUrl } from './formatters';
 
 const postsDirectory = path.join(process.cwd(), '_posts');
 
@@ -137,8 +138,7 @@ export function getAllWorkTypes() {
     allPosts.forEach(post => {
         if (post.workType) {
             post.workType.forEach(type => {
-                // Convert to URL-friendly format
-                const urlType = type.toLowerCase().replace(/[&]/g, '').replace(/\s+/g, '-');
+                const urlType = normalizeForUrl(type);
                 workTypes.add(urlType);
             });
         }
@@ -153,7 +153,34 @@ export function getPostsByWorkType(workType) {
         if (!post.workType) return false;
         const normalizedWorkType = workType.replace(/-/g, ' ').toLowerCase();
         return post.workType.some(type =>
-            type.toLowerCase() === normalizedWorkType
+            type.replace(/-/g, ' ').toLowerCase() === normalizedWorkType
+        );
+    });
+}
+
+export function getAllSectors() {
+    const allPosts = getSortedPostsData();
+    const sectors = new Set();
+
+    allPosts.forEach(post => {
+        if (post.clientSector) {
+            post.clientSector.forEach(sector => {
+                // Convert to URL-friendly format
+                const urlSector = normalizeForUrl(sector);
+                sectors.add(urlSector);
+            });
+        }
+    });
+
+    return Array.from(sectors);
+}
+
+export function getPostsBySector(sector) {
+    const allPosts = getSortedPostsData();
+    return allPosts.filter(post => {
+        if (!post.clientSector) return false;
+        return post.clientSector.some(type =>
+            normalizeForUrl(type) === normalizeForUrl(sector)
         );
     });
 }

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -138,7 +138,7 @@ export function getAllWorkTypes() {
         if (post.workType) {
             post.workType.forEach(type => {
                 // Convert to URL-friendly format
-                const urlType = type.toLowerCase().replace(/\s+/g, '-').replace(/[&]/g, '');
+                const urlType = type.toLowerCase().replace(/[&]/g, '').replace(/\s+/g, '-');
                 workTypes.add(urlType);
             });
         }

--- a/pages/design/[...project].js
+++ b/pages/design/[...project].js
@@ -160,7 +160,9 @@ export default function Project({ isFolder, folderAvailable, folderUrl, folderNa
                 <h3>Discipline</h3>
                 {currentPostData.workType.map((workType, i) => {
                   return (
-                    <p key={i}>{workType}</p>
+                    <Link href={`/work/discipline/${workType.toLowerCase().replace(/[&]/g, '').replace(/\s+/g, '-')}`} key={i}>
+                      <p>{workType}</p>
+                    </Link>
                   )
                 })}
               </div>

--- a/pages/design/[...project].js
+++ b/pages/design/[...project].js
@@ -8,7 +8,7 @@ import GlobalFooter from '@/components/GlobalFooter/GlobalFooter'
 import NextProjectPeek from '@/components/NextProjectPeek/NextProjectPeek'
 import { ProjectArticleHeader } from '@/components/ProjectArticleHeader/ProjectArticleHeader'
 import ProjectArticleAsset from '@/components/ProjectArticleAsset/ProjectArticleAsset'
-import { formatYears } from '@/lib/formatters'
+import { formatYears, normalizeForUrl } from '@/lib/formatters'
 import FolderPage from './folder-page'
 import Link from 'next/link';
 
@@ -150,7 +150,9 @@ export default function Project({ isFolder, folderAvailable, folderUrl, folderNa
                 <h3>Sector</h3>
                 {currentPostData.clientSector.map((clientSector, i) => {
                   return (
-                    <p key={i}>{clientSector}</p>
+                    <Link href={`/work/sector/${normalizeForUrl(clientSector)}`} key={i}>
+                      <p>{clientSector}</p>
+                    </Link>
                   )
                 })}
               </div>
@@ -160,7 +162,7 @@ export default function Project({ isFolder, folderAvailable, folderUrl, folderNa
                 <h3>Discipline</h3>
                 {currentPostData.workType.map((workType, i) => {
                   return (
-                    <Link href={`/work/discipline/${workType.toLowerCase().replace(/[&]/g, '').replace(/\s+/g, '-')}`} key={i}>
+                    <Link href={`/work/discipline/${normalizeForUrl(workType)}`} key={i}>
                       <p>{workType}</p>
                     </Link>
                   )

--- a/pages/design/[...project].scss
+++ b/pages/design/[...project].scss
@@ -111,6 +111,9 @@
             }
 
             .item {
+                >*:not(:first-child) {
+                    margin-top: 2px;
+                }
 
                 h3,
                 p {
@@ -126,11 +129,11 @@
                 }
 
                 a {
-                    display: inline-block;
+                    display: block;
+                    width: fit-content;
                     position: relative;
-
-                    padding-bottom: 4px;
-                    margin-bottom: -4px;
+                    padding-bottom: 1px;
+                    margin-bottom: -1px;
 
                     @media (hover: hover) {
                         &:hover {

--- a/pages/design/folder-page.js
+++ b/pages/design/folder-page.js
@@ -1,26 +1,6 @@
-import './folder-page.scss'
-import GlobalHeader from '@/components/GlobalHeader/GlobalHeader'
-import ProjectsGrid from '@/components/ProjectsGrid/ProjectsGrid'
-import { ProjectThumbnail } from '@/components/ProjectThumbnail/ProjectThumbnail'
-import { NextSeo } from 'next-seo'
-import GlobalFooter from '@/components/GlobalFooter/GlobalFooter'
-import { getSortedPostsData } from '../../lib/posts'
+import ProjectCollection from '@/components/ProjectCollection/ProjectCollection'
 
 export default function FolderPage({ folderName, posts, server }) {
-  const _renderThumbnail = (project, index, priority) => {
-    return (
-      <ProjectThumbnail
-        {...project}
-        id={project.id}
-        as="article"
-        hover
-        key={index}
-        fadeIn={false}
-        priority={priority}
-      />
-    )
-  }
-
   const _normalizedFolderName = () => {
     const cleanedFolderName = folderName.replaceAll("-", " ");
     const words = cleanedFolderName.split(" ");
@@ -41,60 +21,11 @@ export default function FolderPage({ folderName, posts, server }) {
   }
 
   return (
-    <>
-      <NextSeo
-        title={`${_folderDisplayName()}  — Laura Sandoval`}
-        description="Digital Product Designer & Engineer. Featured works include projects for Uber, Uber Eats, Cornershop, among others."
-        openGraph={{
-          title: `${_folderDisplayName()}  — Laura Sandoval`,
-          description: "Digital Product Designer & Engineer. Featured works include projects for Uber, Uber Eats, Cornershop, among others.",
-          images: [
-            {
-              url: `${server}${posts[0].ogImage}`,
-            }
-          ],
-        }}
-        twitter={{
-          handle: "@laurasideral",
-          cardType: "summary_large_image",
-        }}
-        additionalLinkTags={[
-          {
-            rel: "icon",
-            href: `${server}/favicon.ico`,
-          },
-          {
-            rel: "apple-touch-icon",
-            href: `${server}/logo192.png`
-          }
-        ]}
-        additionalMetaTags={[
-          {
-            name: "theme-color",
-            content: "#FFFFFF",
-          },
-        ]}
-      />
-
-      <GlobalHeader sticky fadeIn={false} />
-
-      <div className="folder_page">
-        <div className="folder_name_header">
-          <div className="basic_info">
-            <h2 className="title">{_folderDisplayName()}</h2>
-            <h2 className="subtitle">{`${posts.length} ${posts.length === 1 ? "project" : "projects"}`}</h2>
-          </div>
-        </div>
-
-        <ProjectsGrid showAll>
-          {posts.map((project, index) => {
-            return _renderThumbnail(project, index, (index == 0 || index == 1))
-          })}
-        </ProjectsGrid>
-      </div>
-
-      <GlobalFooter />
-    </>
+    <ProjectCollection
+      title={_folderDisplayName()}
+      posts={posts}
+      server={server}
+    />
   )
 }
 

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,6 +1,6 @@
-import { getAllFolders, getSortedPostsData } from "@/lib/posts";
+import { getAllFolders, getSortedPostsData, getAllWorkTypes } from "@/lib/posts";
 
-function generateSiteMap(designWorkData, designWorkFoldersData, server) {
+function generateSiteMap(designWorkData, designWorkFoldersData, workTypes, server) {
   return `<?xml version="1.0" encoding="UTF-8"?>
    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
      <url>
@@ -14,17 +14,24 @@ function generateSiteMap(designWorkData, designWorkFoldersData, server) {
      </url>
      ${designWorkData.map((project) => {
     return `
-       <url>
-           <loc>${`${server}/design/${project.id}`}</loc>
-       </url>
-     `;
+         <url>
+             <loc>${`${server}/design/${project.id}`}</loc>
+         </url>
+       `;
   }).join('')}
      ${designWorkFoldersData.map((folder) => {
     return `
-       <url>
-           <loc>${`${server}/design/${folder.params.project[0]}`}</loc>
-       </url>
-     `;
+         <url>
+             <loc>${`${server}/design/${folder.params.project[0]}`}</loc>
+         </url>
+       `;
+  }).join('')}
+     ${workTypes.map((type) => {
+    return `
+         <url>
+             <loc>${`${server}/work/discipline/${type}`}</loc>
+         </url>
+       `;
   }).join('')}
    </urlset>
  `;
@@ -38,20 +45,18 @@ export async function getServerSideProps(context) {
   const dev = process.env.NODE_ENV !== 'production';
   const server = dev ? `http://localhost:3000` : `https://${context.req.headers.host}`;
 
-  // Fetch and sort all posts data
   const designWorkData = getSortedPostsData();
   const designWorkFoldersData = getAllFolders();
+  const workTypes = getAllWorkTypes();
 
-  // Generate the XML sitemap with the project data
-  const sitemap = generateSiteMap(designWorkData, designWorkFoldersData, server);
+  const sitemap = generateSiteMap(designWorkData, designWorkFoldersData, workTypes, server);
 
   context.res.setHeader('Content-Type', 'text/xml');
-  // Send the XML to the browser
   context.res.write(sitemap);
   context.res.end();
 
   return {
-    props: {}, // No props are needed as this page just serves the XML
+    props: {},
   };
 }
 

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,6 +1,6 @@
-import { getAllFolders, getSortedPostsData, getAllWorkTypes } from "@/lib/posts";
+import { getAllFolders, getSortedPostsData, getAllWorkTypes, getAllSectors } from "@/lib/posts";
 
-function generateSiteMap(designWorkData, designWorkFoldersData, workTypes, server) {
+function generateSiteMap(designWorkData, designWorkFoldersData, workTypes, sectors, server) {
   return `<?xml version="1.0" encoding="UTF-8"?>
    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
      <url>
@@ -33,6 +33,13 @@ function generateSiteMap(designWorkData, designWorkFoldersData, workTypes, serve
          </url>
        `;
   }).join('')}
+     ${sectors.map((sector) => {
+    return `
+         <url>
+             <loc>${`${server}/work/sector/${sector}`}</loc>
+         </url>
+       `;
+  }).join('')}
    </urlset>
  `;
 }
@@ -48,8 +55,9 @@ export async function getServerSideProps(context) {
   const designWorkData = getSortedPostsData();
   const designWorkFoldersData = getAllFolders();
   const workTypes = getAllWorkTypes();
+  const sectors = getAllSectors();
 
-  const sitemap = generateSiteMap(designWorkData, designWorkFoldersData, workTypes, server);
+  const sitemap = generateSiteMap(designWorkData, designWorkFoldersData, workTypes, sectors, server);
 
   context.res.setHeader('Content-Type', 'text/xml');
   context.res.write(sitemap);

--- a/pages/work/discipline/[type].js
+++ b/pages/work/discipline/[type].js
@@ -33,7 +33,7 @@ export async function getStaticProps({ params }) {
             posts,
             server: process.env.NODE_ENV !== 'production'
                 ? 'http://localhost:3000'
-                : 'https://laurasandoval.com', // Replace with your production domain
+                : 'https://lau.work',
         },
         // Revalidate every hour
         revalidate: 3600

--- a/pages/work/discipline/[type].js
+++ b/pages/work/discipline/[type].js
@@ -12,7 +12,7 @@ export default function WorkTypePage({ type, posts, server }) {
             title={displayTitle}
             posts={posts}
             server={server}
-            description={`Projects in ${displayTitle} by Laura Sandoval`}
+            description={`${displayTitle} projects by Laura Sandoval.`}
         />
     )
 }

--- a/pages/work/discipline/[type].js
+++ b/pages/work/discipline/[type].js
@@ -1,0 +1,54 @@
+import { getAllWorkTypes, getPostsByWorkType } from '@/lib/posts'
+import ProjectCollection from '@/components/ProjectCollection/ProjectCollection'
+
+export default function WorkTypePage({ type, posts, server }) {
+    const displayTitle = type
+        .split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+
+    return (
+        <ProjectCollection
+            title={displayTitle}
+            posts={posts}
+            server={server}
+            description={`Projects in ${displayTitle} by Laura Sandoval`}
+        />
+    )
+}
+
+export async function getStaticProps({ params }) {
+    const { type } = params;
+    const posts = getPostsByWorkType(type);
+
+    if (!posts.length) {
+        return {
+            notFound: true
+        }
+    }
+
+    return {
+        props: {
+            type,
+            posts,
+            server: process.env.NODE_ENV !== 'production'
+                ? 'http://localhost:3000'
+                : 'https://laurasandoval.com', // Replace with your production domain
+        },
+        // Revalidate every hour
+        revalidate: 3600
+    }
+}
+
+export async function getStaticPaths() {
+    const workTypes = getAllWorkTypes();
+
+    const paths = workTypes.map(type => ({
+        params: { type }
+    }));
+
+    return {
+        paths,
+        fallback: false
+    }
+} 

--- a/pages/work/sector/[type].js
+++ b/pages/work/sector/[type].js
@@ -1,0 +1,73 @@
+import { getAllSectors, getPostsBySector } from '@/lib/posts'
+import { normalizeForUrl } from '@/lib/formatters'
+import ProjectCollection from '@/components/ProjectCollection/ProjectCollection'
+
+export default function SectorPage({ type, posts, server }) {
+    const _normalizedSectorName = () => {
+        const cleanedSectorName = type.replaceAll("-", " ");
+        const words = cleanedSectorName.split(" ");
+
+        for (let i = 0; i < words.length; i++) {
+            words[i] = words[i][0].toUpperCase() + words[i].substr(1);
+        }
+
+        return words.join(" ");
+    }
+
+    const _sectorDisplayName = () => {
+        if (!posts[0].clientSector) {
+            return _normalizedSectorName()
+        }
+
+        const matchingSector = posts[0].clientSector.find(sector =>
+            normalizeForUrl(sector) === type
+        );
+
+        return matchingSector || _normalizedSectorName();
+    }
+
+    return (
+        <ProjectCollection
+            title={_sectorDisplayName()}
+            posts={posts}
+            server={server}
+            description={`${_sectorDisplayName()} projects by Laura Sandoval.`}
+        />
+    )
+}
+
+export async function getStaticProps({ params }) {
+    const { type } = params;
+    const posts = getPostsBySector(type);
+
+    if (!posts.length) {
+        return {
+            notFound: true
+        }
+    }
+
+    return {
+        props: {
+            type,
+            posts,
+            server: process.env.NODE_ENV !== 'production'
+                ? 'http://localhost:3000'
+                : 'https://lau.work',
+        },
+        // Revalidate every hour
+        revalidate: 3600
+    }
+}
+
+export async function getStaticPaths() {
+    const sectors = getAllSectors();
+
+    const paths = sectors.map(type => ({
+        params: { type }
+    }));
+
+    return {
+        paths,
+        fallback: false
+    }
+}


### PR DESCRIPTION
This PR adds category pages that group projects based on client sector or work type.

Future to-dos:
* Rename URLs from `/design/[project]` to `/work/[project]` to be consistent with the new category pages structure.
* Create a new `/work` URL to see projects grouped by these types.

Special thanks to [Cursor](https://www.cursor.com) which did a lot of the work lol